### PR TITLE
Add administrator dashboard with site statistics and user management

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,15 @@ The `upload.php` script includes error handling and logging mechanisms. Errors a
 1. The dashboard allows users to view and delete their uploaded images.
 2. Users can also customize settings such as file name length and upload endpoint password.
 3. The dashboard is accessible only to logged-in users.
+4. The dashboard includes 4 boxes to show site statistics such as registered users, total uploads, total uploaded data size, and version of the host system.
+
+## Administrator Dashboard
+
+1. The administrator dashboard allows administrators to control service settings, user management, and view site statistics.
+2. Administrators can control allowed file types, general upload size limit, and user management such as suspending or deleting accounts.
+3. The administrator dashboard includes an announcement section.
+4. Administrators can post announcements from the administrator dashboard.
 
 ## License
 
 This project is licensed under the GNU General Public License v3.0. See the `LICENSE` file for more details.
-
-P.S. there are tutorials on youtube.com if you can't follow these steps :)

--- a/admin_dashboard.php
+++ b/admin_dashboard.php
@@ -1,0 +1,124 @@
+<?php
+session_start();
+require 'config.php';
+
+if (!isset($_SESSION['user_id'])) {
+    header("Location: auth.php");
+    exit;
+}
+
+$user_id = $_SESSION['user_id'];
+
+// Check if the user is an administrator
+$stmt = $conn->prepare("SELECT is_admin FROM users WHERE id = ?");
+$stmt->bind_param("i", $user_id);
+$stmt->execute();
+$stmt->bind_result($is_admin);
+$stmt->fetch();
+$stmt->close();
+
+if (!$is_admin) {
+    header("Location: dashboard.php");
+    exit;
+}
+
+// Fetch announcements
+$announcements = [];
+$stmt = $conn->prepare("SELECT id, content FROM announcements ORDER BY created_at DESC");
+$stmt->execute();
+$result = $stmt->get_result();
+while ($row = $result->fetch_assoc()) {
+    $announcements[] = $row;
+}
+$stmt->close();
+
+// Handle form submissions
+if ($_SERVER['REQUEST_METHOD'] == 'POST') {
+    if (isset($_POST['post_announcement'])) {
+        $content = $_POST['announcement_content'];
+        $stmt = $conn->prepare("INSERT INTO announcements (content) VALUES (?)");
+        $stmt->bind_param("s", $content);
+        $stmt->execute();
+        $stmt->close();
+        header("Location: admin_dashboard.php");
+        exit;
+    }
+
+    if (isset($_POST['suspend_user'])) {
+        $user_id_to_suspend = $_POST['user_id'];
+        $stmt = $conn->prepare("UPDATE users SET is_suspended = 1 WHERE id = ?");
+        $stmt->bind_param("i", $user_id_to_suspend);
+        $stmt->execute();
+        $stmt->close();
+        header("Location: admin_dashboard.php");
+        exit;
+    }
+
+    if (isset($_POST['delete_user'])) {
+        $user_id_to_delete = $_POST['user_id'];
+        $stmt = $conn->prepare("DELETE FROM users WHERE id = ?");
+        $stmt->bind_param("i", $user_id_to_delete);
+        $stmt->execute();
+        $stmt->close();
+        header("Location: admin_dashboard.php");
+        exit;
+    }
+
+    if (isset($_POST['set_upload_size'])) {
+        $user_id_to_set = $_POST['user_id'];
+        $upload_size = $_POST['upload_size'];
+        $stmt = $conn->prepare("UPDATE users SET upload_size = ? WHERE id = ?");
+        $stmt->bind_param("ii", $upload_size, $user_id_to_set);
+        $stmt->execute();
+        $stmt->close();
+        header("Location: admin_dashboard.php");
+        exit;
+    }
+}
+?>
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Admin Dashboard</title>
+    <link rel="stylesheet" href="style.css">
+    <script>
+        function toggleMode() {
+            var element = document.body;
+            element.classList.toggle("dark-mode");
+        }
+    </script>
+</head>
+<body>
+    <button onclick="toggleMode()">Toggle Light/Dark Mode</button>
+    <h2>Admin Dashboard</h2>
+
+    <h3>Announcements</h3>
+    <form method="POST" action="admin_dashboard.php">
+        <textarea name="announcement_content" required></textarea>
+        <br>
+        <button type="submit" name="post_announcement">Post Announcement</button>
+    </form>
+    <ul>
+        <?php foreach ($announcements as $announcement): ?>
+            <li><?php echo $announcement['content']; ?></li>
+        <?php endforeach; ?>
+    </ul>
+
+    <h3>User Management</h3>
+    <form method="POST" action="admin_dashboard.php">
+        <label for="user_id">User ID:</label>
+        <input type="number" id="user_id" name="user_id" required>
+        <br>
+        <button type="submit" name="suspend_user">Suspend User</button>
+        <button type="submit" name="delete_user">Delete User</button>
+        <br>
+        <label for="upload_size">Set Upload Size (MB):</label>
+        <input type="number" id="upload_size" name="upload_size" required>
+        <br>
+        <button type="submit" name="set_upload_size">Set Upload Size</button>
+    </form>
+</body>
+</html>

--- a/auth.php
+++ b/auth.php
@@ -11,18 +11,22 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
         exit;
     }
 
-    $stmt = $conn->prepare("SELECT id, password FROM users WHERE username = ?");
+    $stmt = $conn->prepare("SELECT id, password, is_admin FROM users WHERE username = ?");
     $stmt->bind_param("s", $username);
     $stmt->execute();
     $stmt->store_result();
 
     if ($stmt->num_rows > 0) {
-        $stmt->bind_result($id, $hashed_password);
+        $stmt->bind_result($id, $hashed_password, $is_admin);
         $stmt->fetch();
 
         if (password_verify($password, $hashed_password)) {
             $_SESSION['user_id'] = $id;
-            header("Location: dashboard.php");
+            if ($is_admin) {
+                header("Location: admin_dashboard.php");
+            } else {
+                header("Location: dashboard.php");
+            }
             exit;
         } else {
             echo "Invalid username or password.";

--- a/config.php
+++ b/config.php
@@ -9,4 +9,15 @@ $conn = new mysqli(DB_HOST, DB_USER, DB_PASS, DB_NAME);
 if ($conn->connect_error) {
     die("Connection failed: " . $conn->connect_error);
 }
+
+// Create site_statistics table if it doesn't exist
+$createTableQuery = "
+CREATE TABLE IF NOT EXISTS site_statistics (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    value VARCHAR(255) NOT NULL
+)";
+if ($conn->query($createTableQuery) === FALSE) {
+    die("Error creating table: " . $conn->error);
+}
 ?>

--- a/dashboard.php
+++ b/dashboard.php
@@ -25,6 +25,19 @@ $stmt->bind_result($file_name_length, $upload_password);
 $stmt->fetch();
 $stmt->close();
 
+// Fetch site statistics
+$statistics = [];
+$stat_names = ['registered_users', 'total_uploads', 'total_uploaded_data_size', 'host_system_version'];
+foreach ($stat_names as $stat_name) {
+    $stmt = $conn->prepare("SELECT value FROM site_statistics WHERE name = ?");
+    $stmt->bind_param("s", $stat_name);
+    $stmt->execute();
+    $stmt->bind_result($value);
+    $stmt->fetch();
+    $statistics[$stat_name] = $value;
+    $stmt->close();
+}
+
 if ($_SERVER['REQUEST_METHOD'] == 'POST') {
     if (isset($_POST['delete_image'])) {
         $image_id = $_POST['image_id'];
@@ -98,5 +111,19 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
         <br>
         <button type="submit" name="update_settings">Update Settings</button>
     </form>
+
+    <h3>Site Statistics</h3>
+    <div class="statistics-box">
+        <p>Registered Users: <?php echo $statistics['registered_users']; ?></p>
+    </div>
+    <div class="statistics-box">
+        <p>Total Uploads: <?php echo $statistics['total_uploads']; ?></p>
+    </div>
+    <div class="statistics-box">
+        <p>Total Uploaded Data Size: <?php echo $statistics['total_uploaded_data_size']; ?></p>
+    </div>
+    <div class="statistics-box">
+        <p>Host System Version: <?php echo $statistics['host_system_version']; ?></p>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
Add an administrator dashboard to control service settings, user management, and view site statistics.

* **admin_dashboard.php**
  - Add a new file `admin_dashboard.php` to provide the administrator with the ability to control allowed file types, general upload size limit, and user management.
  - Include an announcement section and functionality to post announcements from the administrator dashboard.
  - Add functionality to suspend or delete user accounts and uploaded content, and set specific allowed upload size for users.

* **auth.php**
  - Update the `auth.php` file to redirect administrators to `admin_dashboard.php` upon successful login.

* **config.php**
  - Add a new table `site_statistics` to store site statistics such as registered users, total uploads, total uploaded data size, and version of the host system.

* **dashboard.php**
  - Add 4 boxes to show site statistics such as registered users, total uploads, total uploaded data size, and version of the host system.

* **README.md**
  - Update the `README.md` file to include instructions for the administrator dashboard.
  - Remove unnecessary sections and outdated information.

