### PR TITLE
Add instructions for setting session secret in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ The program can be found over at https://getsharex.com/
 - **FileFormName**: The name of the form field for the file upload (e.g., sharex).
 - **URL**: The URL format for the uploaded file.
 
+### Session Management
+
+- **SESSION_SECRET**: Set the `SESSION_SECRET` environment variable to a strong, unique value. This is used for session management in `index.js`.
+
+To set the `SESSION_SECRET` environment variable, you can use the following command in your terminal:
+
+```sh
+export SESSION_SECRET=your_secret_key
+```
+
+Replace `your_secret_key` with a strong, unique value.
+
 ## Usage
 
 1. Open ShareX and go to `Destinations` > `Custom uploaders`.

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ import express from 'express';
 import mongoose from 'mongoose';
 import bodyParser from 'body-parser';
 import path from 'path';
-import session from 'express-session'; // Pb655
+import session from 'express-session';
 
 const app = express();
 const port = process.env.PORT || 3000;
@@ -14,9 +14,15 @@ app.use(bodyParser.urlencoded({ extended: true }));
 // Middleware for serving static files
 app.use(express.static(path.join(__dirname, 'public')));
 
+// Check if SESSION_SECRET is set
+if (!process.env.SESSION_SECRET) {
+  console.error('Error: SESSION_SECRET environment variable is not set.');
+  process.exit(1);
+}
+
 // Session management middleware for user authentication
 app.use(session({
-  secret: 'your-secret-key',
+  secret: process.env.SESSION_SECRET,
   resave: false,
   saveUninitialized: true,
   cookie: { secure: false } // Set to true if using HTTPS


### PR DESCRIPTION
Add instructions to the README for setting the `SESSION_SECRET` environment variable and update session management in `index.js`.

* **index.js**
  - Import `express-session`.
  - Add a check to ensure `process.env.SESSION_SECRET` is set, and log an error if not.
  - Update session management to use `process.env.SESSION_SECRET` for the `secret` key.

* **README.md**
  - Add instructions for setting the `SESSION_SECRET` environment variable.
  - Update the configuration section to include details on configuring session management.

